### PR TITLE
Use consistent Java version in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
         <java.version>1.8</java.version>
     </properties>
 
-
     <build>
         <plugins>
             <plugin>
@@ -36,12 +35,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
 
 </project>


### PR DESCRIPTION
Java target and source version was set to `11` while the defined property `java.version` has the value of `1.8`. Considering the code does not contain any Java 11 specific syntax, this PR makes the java version consistent to `1.8`. 